### PR TITLE
Auto-initialize GStreamer on first use

### DIFF
--- a/Examples/gst-appsink/main.swift
+++ b/Examples/gst-appsink/main.swift
@@ -4,9 +4,6 @@ import GStreamer
 @main
 struct GstAppSinkExample {
     static func main() async throws {
-        // Initialize GStreamer
-        try GStreamer.initialize()
-
         print("GStreamer version: \(GStreamer.versionString)")
 
         // Create a pipeline with appsink

--- a/Examples/gst-appsrc/main.swift
+++ b/Examples/gst-appsrc/main.swift
@@ -10,7 +10,6 @@ import Foundation
 @main
 struct GstAppSrcExample {
     static func main() async throws {
-        try GStreamer.initialize()
         print("GStreamer version: \(GStreamer.versionString)")
 
         let width = 320

--- a/Examples/gst-audio/main.swift
+++ b/Examples/gst-audio/main.swift
@@ -24,7 +24,6 @@ struct GstAudioExample {
     }
 
     static func main() async throws {
-        try GStreamer.initialize()
         print("GStreamer version: \(GStreamer.versionString)")
 
         // Try backends in order of preference

--- a/Examples/gst-devices/main.swift
+++ b/Examples/gst-devices/main.swift
@@ -9,7 +9,6 @@ import GStreamer
 @main
 struct GstDevicesExample {
     static func main() async throws {
-        try GStreamer.initialize()
         print("GStreamer version: \(GStreamer.versionString)")
         print(String(repeating: "=", count: 60))
 

--- a/Examples/gst-play/main.swift
+++ b/Examples/gst-play/main.swift
@@ -4,9 +4,6 @@ import GStreamer
 @main
 struct GstPlay {
     static func main() async throws {
-        // Initialize GStreamer
-        try GStreamer.initialize()
-
         print("GStreamer version: \(GStreamer.versionString)")
 
         // Create a simple test pipeline

--- a/Examples/gst-tee/main.swift
+++ b/Examples/gst-tee/main.swift
@@ -13,7 +13,6 @@ import GStreamer
 @main
 struct GstTeeExample {
     static func main() async throws {
-        try GStreamer.initialize()
         print("GStreamer version: \(GStreamer.versionString)")
 
         // Pipeline with tee splitting to display and appsink

--- a/Examples/gst-vision/main.swift
+++ b/Examples/gst-vision/main.swift
@@ -12,7 +12,6 @@ import CoreImage
 @main
 struct GstVisionExample {
     static func main() async throws {
-        try GStreamer.initialize()
         print("GStreamer version: \(GStreamer.versionString)")
 
         // Create pipeline with test video

--- a/README.md
+++ b/README.md
@@ -128,10 +128,7 @@ Then add `GStreamer` to your target dependencies:
 ```swift
 import GStreamer
 
-// Initialize GStreamer (once per process)
-try GStreamer.initialize()
-
-// Create and run a pipeline
+// Create and run a pipeline (GStreamer auto-initializes)
 let pipeline = try Pipeline("videotestsrc num-buffers=100 ! autovideosink")
 try pipeline.play()
 
@@ -154,8 +151,6 @@ pipeline.stop()
 
 ```swift
 import GStreamer
-
-try GStreamer.initialize()
 
 let pipeline = try Pipeline("""
     videotestsrc num-buffers=10 ! \
@@ -202,8 +197,6 @@ Capture frames from a USB webcam on Linux:
 ```swift
 import GStreamer
 
-try GStreamer.initialize()
-
 // Basic webcam capture
 let pipeline = try Pipeline("""
     v4l2src device=/dev/video0 ! \
@@ -245,8 +238,6 @@ Capture audio from ALSA devices:
 ```swift
 import GStreamer
 
-try GStreamer.initialize()
-
 // Capture from default ALSA device
 let pipeline = try Pipeline("""
     alsasrc device=default ! \
@@ -283,8 +274,6 @@ Capture audio from PipeWire:
 
 ```swift
 import GStreamer
-
-try GStreamer.initialize()
 
 // Capture from default PipeWire audio source (microphone)
 let pipeline = try Pipeline("""
@@ -367,8 +356,6 @@ Capture audio from PulseAudio:
 ```swift
 import GStreamer
 
-try GStreamer.initialize()
-
 // Capture from default PulseAudio source
 let pipeline = try Pipeline("""
     pulsesrc ! \
@@ -420,8 +407,6 @@ Discover available cameras and microphones programmatically:
 ```swift
 import GStreamer
 
-try GStreamer.initialize()
-
 let monitor = DeviceMonitor()
 
 // List all cameras
@@ -452,8 +437,6 @@ Use hardware-accelerated capture on NVIDIA Jetson:
 
 ```swift
 import GStreamer
-
-try GStreamer.initialize()
 
 // CSI camera with nvarguscamerasrc (IMX219, IMX477, etc.)
 let pipeline = try Pipeline("""
@@ -495,8 +478,6 @@ Receive video from IP cameras:
 
 ```swift
 import GStreamer
-
-try GStreamer.initialize()
 
 let pipeline = try Pipeline("""
     rtspsrc location=rtsp://camera.local/stream latency=100 ! \


### PR DESCRIPTION
## Summary

- GStreamer now auto-initializes with default config when creating Pipeline, DeviceMonitor, or other types
- Explicit `GStreamer.initialize()` is now optional - only needed for custom configuration like plugin paths
- Reduces boilerplate for the common case

## Before

```swift
import GStreamer

try GStreamer.initialize()  // Required
let pipeline = try Pipeline("videotestsrc ! autovideosink")
```

## After

```swift
import GStreamer

let pipeline = try Pipeline("videotestsrc ! autovideosink")  // Just works
```

## Custom Configuration (still supported)

```swift
var config = GStreamer.Configuration()
config.pluginPaths = ["/opt/gstreamer/plugins"]
try GStreamer.initialize(config)  // Call before creating pipelines
```

## Test plan

- [x] All 65 tests pass
- [x] All examples build and run without explicit initialization
- [x] Custom configuration still works when needed